### PR TITLE
Bind classroom resource upload form to existing manager

### DIFF
--- a/frontend/classroom/classroom.js
+++ b/frontend/classroom/classroom.js
@@ -30,20 +30,12 @@ class ClassroomManager {
         });
 
         // Resource upload form
-       document.addEventListener('DOMContentLoaded', () => {
-    const resourceForm = document.getElementById('resourceUploadForm');
-
-    if (resourceForm) {
-        resourceForm.addEventListener('submit', (e) => {
-            e.preventDefault();
-            const manager = new ClassroomManager(); // ✅ create instance
-            manager.handleResourceUpload(e);        // ✅ call instance method
-        });
-
-    } else {
-        console.error('resourceUploadForm not found in DOM.');
-    }
-});
+        const resourceForm = document.getElementById('resourceUploadForm');
+        if (resourceForm) {
+            resourceForm.addEventListener('submit', this.handleResourceUpload.bind(this));
+        } else {
+            console.error('resourceUploadForm not found in DOM.');
+        }
 
     }
 
@@ -222,6 +214,7 @@ class ClassroomManager {
     }
 
     async handleResourceUpload(e) {
+        e.preventDefault();
         const fileInput = document.getElementById('resourceFile');
         const title = document.getElementById('resourceTitle').value.trim();
         const description = document.getElementById('resourceDescription').value.trim();


### PR DESCRIPTION
## Summary
- Bind `#resourceUploadForm` submit handler during init instead of waiting for DOMContentLoaded
- Stop creating extra `ClassroomManager` instances and handle uploads via `this.handleResourceUpload`
- Add default prevention to `handleResourceUpload`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b08b5b38483219f70d552e879e729