### PR TITLE
chore: clean group routes

### DIFF
--- a/backend/routes/groupRoutes.js
+++ b/backend/routes/groupRoutes.js
@@ -6,8 +6,6 @@ const Classroom = require('../models/Classroom');
 const auth = require('../middleware/auth');
 
 // Create a new group
-// Create a new group
-// Create a new group
 router.post('/create', auth, async (req, res) => {
   console.log('Received request to create group:', req.body);
 
@@ -44,36 +42,6 @@ router.post('/create', auth, async (req, res) => {
     return res.status(500).json({ message: 'Error creating group' });
   }
 });
-
-// router.post('/create', auth, async (req, res) => {
-//   console.log('Received request to create group:', req.body); // ✅ Debugging log
-
-//   const { classroomId, name, description, isPrivate, groupType } = req.body;
-//   let joinCode = null;
-
-//   try {
-//     if (isPrivate) {
-//       joinCode = Math.random().toString(36).substring(2, 8).toUpperCase();
-//     }
-
-//     const group = new Group({
-//       classroomId,
-//       name: name,
-//       description,
-//       isPrivate,
-//       joinCode,
-//       groupType,
-//       createdBy: req.user._id,
-//       members: [req.user._id]
-//     });
-
-//     await group.save();
-//     res.status(201).json({ message: 'Group created successfully', group });
-//   } catch (err) {
-//     console.error('Group creation error:', err);
-//     res.status(500).json({ message: 'Error creating group' });
-//   }
-// });
 
 // Join a group (with or without code)
 router.post('/join', auth, async (req, res) => {


### PR DESCRIPTION
## Summary
- remove duplicate 'Create a new group' comments
- delete obsolete commented-out implementation block

## Testing
- `npm test` *(fails: Missing script "test")*
- `(cd backend && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b08b3334883218906c197fc09d703