### PR TITLE
feat: add classroom and group management options

### DIFF
--- a/backend/controllers/classroomController.js
+++ b/backend/controllers/classroomController.js
@@ -119,3 +119,25 @@ exports.deleteClassroom = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };
+
+// ✅ Leave a classroom
+exports.leaveClassroom = async (req, res) => {
+  const classroomId = req.params.id;
+  const userId = req.user.id;
+
+  try {
+    const classroom = await Classroom.findById(classroomId);
+    if (!classroom) {
+      return res.status(404).json({ message: 'Classroom not found' });
+    }
+
+    classroom.members = classroom.members.filter(m => m.toString() !== userId);
+    await classroom.save();
+
+    await User.findByIdAndUpdate(userId, { $pull: { classrooms: classroomId } });
+
+    res.json({ message: 'Left classroom successfully' });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/routes/classroomRoutes.js
+++ b/backend/routes/classroomRoutes.js
@@ -19,4 +19,7 @@ router.post('/:id/add', postController.addContent);
 // ✅ Delete a classroom (and its content)
 router.delete('/:id', auth, classroomController.deleteClassroom);  // <-- New route added
 
+// ✅ Leave a classroom
+router.post('/:id/leave', auth, classroomController.leaveClassroom);
+
 module.exports = router;

--- a/frontend/classroom/classroom.css
+++ b/frontend/classroom/classroom.css
@@ -190,6 +190,23 @@ body {
   box-shadow: 0 8px 20px rgba(9, 12, 2, 0.2);
 }
 
+.btn-danger {
+  background: #f44336;
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btn-danger:hover {
+  background: #d32f2f;
+}
+
+.classroom-actions {
+  margin-top: 20px;
+}
+
 .btn-icon {
   font-size: 1.2rem;
 }

--- a/frontend/classroom/classroom.html
+++ b/frontend/classroom/classroom.html
@@ -96,10 +96,6 @@
                   <span class="info-value" id="classroomSubject">-</span>
                 </div>
                 <div class="info-item">
-                  <span class="info-label">Created:</span>
-                  <span class="info-value" id="classroomCreated">-</span>
-                </div>
-                <div class="info-item">
                   <span class="info-label">Members:</span>
                   <span class="info-value" id="classroomMemberCount">-</span>
                 </div>
@@ -107,6 +103,13 @@
                   <span class="info-label">Role:</span>
                   <span class="info-value" id="classroomRole">-</span>
                 </div>
+                <div class="info-item">
+                  <span class="info-label">Classroom Code:</span>
+                  <span class="info-value" id="classroomCode">-</span>
+                </div>
+              </div>
+              <div class="classroom-actions">
+                <button class="btn-danger" id="deleteClassroomBtn">Delete Classroom</button>
               </div>
             </div>
           </div>

--- a/frontend/groups/groups.css
+++ b/frontend/groups/groups.css
@@ -312,6 +312,17 @@ body {
     box-shadow: 0 4px 12px rgba(9, 12, 2, 0.3);
 }
 
+.action-btn.danger {
+    background: #f44336;
+    color: #fff;
+    border-color: #f44336;
+}
+
+.action-btn.danger:hover {
+    background: #d32f2f;
+    color: #fff;
+}
+
 .action-btn:hover:not(.primary) {
     background: rgba(9, 12, 2, 0.1);
     color: #090C02;


### PR DESCRIPTION
## Summary
- allow users to delete or leave classrooms, and display classroom join code in overview
- support group deletion/leave actions, join code validation, and show join codes
- fix group member counts and add UI styling for destructive actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix backend test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b033e05c48321bad9dcb4ed303552