### PR TITLE
Add management actions for classrooms and groups

### DIFF
--- a/frontend/classroom/classroom.html
+++ b/frontend/classroom/classroom.html
@@ -96,8 +96,8 @@
                   <span class="info-value" id="classroomSubject">-</span>
                 </div>
                 <div class="info-item">
-                  <span class="info-label">Created:</span>
-                  <span class="info-value" id="classroomCreated">-</span>
+                  <span class="info-label">Classroom Code:</span>
+                  <span class="info-value" id="classroomCode">-</span>
                 </div>
                 <div class="info-item">
                   <span class="info-label">Members:</span>

--- a/frontend/classroom/classroom.js
+++ b/frontend/classroom/classroom.js
@@ -133,9 +133,10 @@ class ClassroomManager {
                 
                 // Add to recent classrooms
                 this.addToRecentClassrooms({
-                    id: data.classroom?.id || Date.now(),
+                    id: data.classroom?._id || Date.now(),
                     name: className,
                     subject: classSubject,
+                    code: data.classroom?.code,
                     role: 'teacher',
                     joinedAt: new Date().toISOString()
                 });
@@ -194,9 +195,10 @@ class ClassroomManager {
                 
                 // Add to recent classrooms
                 this.addToRecentClassrooms({
-                    id: data.classroom?.id || Date.now(),
+                    id: data.classroom?._id || Date.now(),
                     name: data.classroom?.name || `Classroom ${joinCode}`,
                     subject: data.classroom?.subject || 'General',
+                    code: data.classroom?.code || joinCode,
                     role: 'student',
                     joinedAt: new Date().toISOString()
                 });
@@ -427,6 +429,7 @@ class ClassroomManager {
                 id: 1,
                 name: 'Advanced Physics',
                 subject: 'Physics',
+                code: 'PHY123',
                 role: 'student',
                 joinedAt: new Date(Date.now() - 86400000).toISOString(),
                 members: [
@@ -440,6 +443,7 @@ class ClassroomManager {
                 id: 2,
                 name: 'Mathematics 101',
                 subject: 'Mathematics',
+                code: 'MATH101',
                 role: 'teacher',
                 joinedAt: new Date(Date.now() - 172800000).toISOString(),
                 members: [
@@ -483,10 +487,11 @@ class ClassroomManager {
         }
 
         container.innerHTML = this.recentClassrooms.map(classroom => `
-            <div class="recent-classroom-item" onclick="openClassroomView(${classroom.id})">
+            <div class="recent-classroom-item" onclick="openClassroomView('${classroom.id}')">
                 <div class="recent-classroom-header">
                     <div class="recent-classroom-icon">${classroom.role === 'teacher' ? '👨‍🏫' : '👨‍🎓'}</div>
                     <div class="recent-classroom-name">${classroom.name}</div>
+                    <button class="delete-classroom" onclick="deleteClassroom('${classroom.id}'); event.stopPropagation();">✖</button>
                 </div>
                 <div class="recent-classroom-subject">${classroom.subject}</div>
                 <div class="recent-classroom-meta">
@@ -495,6 +500,33 @@ class ClassroomManager {
                 </div>
             </div>
         `).join('');
+    }
+
+    async deleteClassroom(classroomId) {
+        if (!confirm('Are you sure you want to delete this classroom?')) return;
+
+        const token = localStorage.getItem('token');
+        if (!token) {
+            this.showMessage('Please log in first', 'error');
+            return;
+        }
+
+        try {
+            const res = await fetch(`http://localhost:5002/api/classrooms/${classroomId}`, {
+                method: 'DELETE',
+                headers: { Authorization: token }
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.message || 'Failed to delete classroom');
+
+            this.recentClassrooms = this.recentClassrooms.filter(c => String(c.id) !== String(classroomId));
+            this.saveRecentClassrooms();
+            this.renderRecentClassrooms();
+            this.showMessage('Classroom deleted successfully!', 'success');
+        } catch (err) {
+            console.error('Delete classroom error:', err);
+            this.showMessage(err.message || 'Error deleting classroom', 'error');
+        }
     }
 
     formatDate(dateString) {
@@ -543,14 +575,14 @@ class ClassroomManager {
     }
 
     openClassroomView(classroomId) {
-        const classroom = this.recentClassrooms.find(c => c.id === classroomId);
+        const classroom = this.recentClassrooms.find(c => String(c.id) === String(classroomId));
         if (classroom) {
             this.currentClassroom = classroom;
             
             // Populate classroom info
             document.getElementById('classroomTitle').textContent = classroom.name;
             document.getElementById('classroomSubject').textContent = classroom.subject;
-            document.getElementById('classroomCreated').textContent = this.formatDate(classroom.joinedAt);
+            document.getElementById('classroomCode').textContent = classroom.code || '-';
             const memberCount = classroom.members ? classroom.members.length : 0;
             document.getElementById('classroomMemberCount').textContent = `${memberCount} members`;
             document.getElementById('classroomRole').textContent = classroom.role;
@@ -576,6 +608,10 @@ function openClassroomView(classroomId) {
 
 function closeClassroomView() {
     classroomManager.closeClassroomView();
+}
+
+function deleteClassroom(classroomId) {
+    classroomManager.deleteClassroom(classroomId);
 }
 
 function downloadResource(resourceId) {


### PR DESCRIPTION
## Summary
- allow sharing classroom join codes and remove outdated created info
- add classroom deletion with API integration
- support group joining by code, leaving/deleting groups, and show join code in details

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix backend test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689b0f714cbc8321a036ee1f8df97d6c