### PR TITLE
Remove role toggle from auth forms

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -4,7 +4,7 @@ const User = require('../models/User');
 
 // Register Controller
 const register = async (req, res) => {
-  const { name, email, password, role } = req.body;
+  const { name, email, password } = req.body;
 
   try {
     // Check if user already exists
@@ -15,8 +15,8 @@ const register = async (req, res) => {
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(password, salt);
 
-    // Create new user
-    user = new User({ name, email, password: hashedPassword, role });
+    // Create new user without role
+    user = new User({ name, email, password: hashedPassword });
     await user.save();
 
     // Generate token
@@ -31,20 +31,11 @@ const register = async (req, res) => {
 
 // Login Controller
 const login = async (req, res) => {
-  const { email, password, role } = req.body;
-
-  console.log("Login request body:", req.body);
+  const { email, password } = req.body;
 
   try {
-    // Check for both email and role match
-    const user = await User.findOne({ email, role });
-    console.log('User found with email & role:', user);
-
+    const user = await User.findOne({ email });
     if (!user) {
-      // Debug: Check if user exists with email alone
-      const userByEmail = await User.findOne({ email });
-      console.log('User found with email only:', userByEmail);
-
       return res.status(400).json({ message: 'User does not exist' });
     }
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -4,7 +4,6 @@ const userSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
-  role: { type: String, enum: ['student', 'teacher'], default: 'student' },
   classrooms: [{
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Classroom',

--- a/frontend/auth/auth.css
+++ b/frontend/auth/auth.css
@@ -141,84 +141,6 @@ body {
     font-weight: 500;
 }
 
-.role-selector {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 30px;
-    padding: 12px 0;
-}
-
-.role-label {
-    font-size: 0.9rem;
-    color: #090C02;
-    font-weight: 500;
-}
-
-.toggle-switch {
-    display: flex;
-    align-items: center;
-}
-
-.toggle-switch input {
-    display: none;
-}
-
-.toggle-label {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    gap: 10px;
-}
-
-.toggle-text {
-    font-size: 0.8rem;
-    color: #666;
-    font-weight: 500;
-    transition: color 0.3s ease;
-}
-
-.toggle-slider {
-    width: 50px;
-    height: 24px;
-    background: rgba(9, 12, 2, 0.1);
-    border-radius: 12px;
-    position: relative;
-    transition: background 0.3s ease;
-}
-
-.toggle-slider::before {
-    content: '';
-    position: absolute;
-    width: 20px;
-    height: 20px;
-    background: white;
-    border-radius: 50%;
-    top: 2px;
-    left: 2px;
-    transition: transform 0.3s ease;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.toggle-switch input:checked + .toggle-label .toggle-slider {
-    background: #090C02;
-}
-
-.toggle-switch input:checked + .toggle-label .toggle-slider::before {
-    transform: translateX(26px);
-}
-
-.toggle-switch input:checked + .toggle-label .toggle-text:first-child {
-    color: #666;
-}
-
-.toggle-switch input:checked + .toggle-label .toggle-text:last-child {
-    color: #090C02;
-}
-
-.toggle-switch input:not(:checked) + .toggle-label .toggle-text:first-child {
-    color: #090C02;
-}
 
 .auth-btn {
     width: 100%;
@@ -233,6 +155,7 @@ body {
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;
+    margin-top: 10px;
 }
 
 .auth-btn::before {

--- a/frontend/auth/auth.html
+++ b/frontend/auth/auth.html
@@ -31,17 +31,6 @@
             <input type="password" id="login-password" name="password" required>
             <label for="login-password">Password</label>
         </div>
-        <div class="role-selector">
-            <span class="role-label">Role:</span>
-            <div class="toggle-switch">
-                <input type="checkbox" id="login-role-toggle" name="role">
-                <label for="login-role-toggle" class="toggle-label">
-                    <span class="toggle-text">Student</span>
-                    <span class="toggle-slider"></span>
-                    <span class="toggle-text">Teacher</span>
-                </label>
-            </div>
-        </div>
         <button type="submit" class="auth-btn">Login</button>
     </form>
 </div>
@@ -65,17 +54,6 @@
         <div class="form-group">
             <input type="password" id="signup-confirm" name="confirmPassword" required>
             <label for="signup-confirm">Confirm Password</label>
-        </div>
-        <div class="role-selector">
-            <span class="role-label">Role:</span>
-            <div class="toggle-switch">
-                <input type="checkbox" id="signup-role-toggle" name="role">
-                <label for="signup-role-toggle" class="toggle-label">
-                    <span class="toggle-text">Student</span>
-                    <span class="toggle-slider"></span>
-                    <span class="toggle-text">Teacher</span>
-                </label>
-            </div>
         </div>
         <button type="submit" class="auth-btn">Sign Up</button>
     </form>

--- a/frontend/auth/auth.js
+++ b/frontend/auth/auth.js
@@ -16,11 +16,6 @@ class AuthManager {
             form.addEventListener('submit', (e) => this.handleFormSubmit(e));
         });
 
-        // Role toggle animations
-        const roleToggles = document.querySelectorAll('.toggle-switch input');
-        roleToggles.forEach(toggle => {
-            toggle.addEventListener('change', (e) => this.handleRoleToggle(e));
-        });
     }
 
     switchTab(tabName) {
@@ -76,12 +71,11 @@ class AuthManager {
         // CORRECTED: Use proper field names from the FormData object (from name attribute, not ID)
         const email = formData.get('email');      // was: formData.get('login-email')
         const password = formData.get('password'); // was: formData.get('login-password')
-        const role = document.getElementById('login-role-toggle').checked ? 'teacher' : 'student'; // unchanged
 
         fetch('http://localhost:5002/api/auth/login', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ email, password, role }) // unchanged
+            body: JSON.stringify({ email, password })
         })
         .then(res => res.json().then(data => ({ status: res.status, body: data })))
         .then(({ status, body }) => {
@@ -105,7 +99,6 @@ class AuthManager {
         const email = formData.get('email');
         const password = formData.get('password');
         const confirm = formData.get('confirmPassword');
-        const role = document.getElementById('signup-role-toggle').checked ? 'teacher' : 'student';
 
         if (password !== confirm) {
             this.showMessage("Passwords don't match", 'error');
@@ -115,7 +108,7 @@ class AuthManager {
         fetch('http://localhost:5002/api/auth/register', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name, email, password, role })
+            body: JSON.stringify({ name, email, password })
         })
         .then(res => res.json().then(data => ({ status: res.status, body: data })))
         .then(({ status, body }) => {
@@ -134,15 +127,6 @@ class AuthManager {
     handleForgotPassword(formData) {
         const email = formData.get('forgot-email');
         this.showMessage(`If ${email} exists, a reset link will be sent.`, 'success');
-    }
-
-    handleRoleToggle(e) {
-        const toggle = e.target;
-        const label = toggle.nextElementSibling;
-        label.style.transform = 'scale(0.95)';
-        setTimeout(() => {
-            label.style.transform = 'scale(1)';
-        }, 150);
     }
 
     showMessage(message, type) {


### PR DESCRIPTION
## Summary
- drop student/teacher role toggle from login and signup forms
- simplify auth logic to omit role handling
- remove role field from user schema and backend auth controller

## Testing
- `npm run build`
- `node --check backend/controllers/authController.js && node --check backend/models/User.js`


------
https://chatgpt.com/codex/tasks/task_e_689c1ff163448321aa62222ff25bc2c8