### PR TITLE
Improve chatbox message listing and send button style

### DIFF
--- a/frontend/chatbox/chatbox.css
+++ b/frontend/chatbox/chatbox.css
@@ -215,6 +215,37 @@ body {
     padding: 20px;
 }
 
+.message-input {
+    padding: 10px;
+    border-top: 1px solid #ddd;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.message-field {
+    flex: 1;
+    padding: 10px;
+    border: 1px solid rgba(9, 12, 2, 0.1);
+    border-radius: 20px;
+    outline: none;
+}
+
+.send-btn {
+    background: #090C02;
+    color: white;
+    border: none;
+    border-radius: 20px;
+    padding: 8px 16px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.3s ease;
+}
+
+.send-btn:hover {
+    background: rgba(9, 12, 2, 0.8);
+}
+
 .chat-welcome {
     display: flex;
     flex-direction: column;

--- a/frontend/chatbox/chatbox.html
+++ b/frontend/chatbox/chatbox.html
@@ -37,11 +37,11 @@
         <div class="chat-area" id="chatArea">
           <!-- Messages will go here -->
           <div id="messages" style="padding: 20px; max-height: 500px; overflow-y: auto;"></div>
-          
+
           <!-- Message Input -->
-          <div class="message-input" style="padding: 10px; border-top: 1px solid #ddd;">
-            <input type="text" id="messageInput" placeholder="Type a message..." style="width: 80%; padding: 10px;" />
-            <button onclick="sendMessage()" style="padding: 10px 20px;">Send</button>
+          <div class="message-input">
+            <input type="text" id="messageInput" class="message-field" placeholder="Type a message..." />
+            <button id="sendButton" class="send-btn" onclick="sendMessage()">Send</button>
           </div>
         </div>
       </div>
@@ -76,6 +76,7 @@
 
     const messagesContainer = document.getElementById('messages');
     const messageInput = document.getElementById('messageInput');
+    const chatList = document.getElementById('chatList');
 
     socket.on('connect', () => {
       console.log('✅ Connected to Socket.IO server');
@@ -92,10 +93,27 @@
       messagesContainer.scrollTop = messagesContainer.scrollHeight;
     });
 
+    function addChatListItem(msg) {
+      let item = document.querySelector('.chat-item.self');
+      if (!item) {
+        item = document.createElement('div');
+        item.className = 'chat-item self';
+        item.innerHTML = `
+          <div class="chat-avatar">YO</div>
+          <div class="chat-info">
+            <div class="chat-name">You</div>
+            <div class="chat-last-message"></div>
+          </div>`;
+        chatList.appendChild(item);
+      }
+      item.querySelector('.chat-last-message').innerText = msg;
+    }
+
     function sendMessage() {
       const msg = messageInput.value;
       if (msg.trim() !== '') {
         socket.emit('chat message', msg);
+        addChatListItem(msg);
         messageInput.value = '';
       }
     }


### PR DESCRIPTION
## Summary
- Add UI logic to append sent messages to the chat list
- Style send button to match Direct tab and clean up message input

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c2a5e52e48321aefa1ea1d7a766d7