### PR TITLE
feat: improve dark theme styling

### DIFF
--- a/frontend/common/sidebar.css
+++ b/frontend/common/sidebar.css
@@ -256,3 +256,55 @@
 .sidebar-nav::-webkit-scrollbar-thumb:hover {
     background: rgba(9, 12, 2, 0.3);
 }
+
+/* Dark theme */
+.theme-dark .sidebar {
+    background: rgba(33, 33, 33, 0.95);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+.theme-dark .sidebar-header,
+.theme-dark .sidebar-footer {
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+.theme-dark .brand-title,
+.theme-dark .nav-item,
+.theme-dark .nav-icon,
+.theme-dark .nav-text,
+.theme-dark .logout-btn {
+    color: #e0e0e0;
+}
+
+.theme-dark .sidebar-toggle:hover,
+.theme-dark .nav-item:hover {
+    background: rgba(255, 255, 255, 0.05);
+    color: #fff;
+}
+
+.theme-dark .nav-item.active {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+}
+
+.theme-dark .nav-item.active::before {
+    background: #fff;
+}
+
+.theme-dark .hamburger,
+.theme-dark .hamburger::before,
+.theme-dark .hamburger::after {
+    background: #e0e0e0;
+}
+
+.theme-dark .main-content {
+    background: #121212;
+}
+
+.theme-dark .sidebar-nav::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.theme-dark .sidebar-nav::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.3);
+}

--- a/frontend/common/sidebar.js
+++ b/frontend/common/sidebar.js
@@ -166,5 +166,13 @@ function logout() {
 
 // Initialize sidebar when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
+    // Apply saved theme preference across pages
+    const settings = JSON.parse(localStorage.getItem('paperly_settings') || '{}');
+    let theme = settings.theme || 'light';
+    if (theme === 'auto' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        theme = 'dark';
+    }
+    document.body.classList.toggle('theme-dark', theme === 'dark');
+
     new Sidebar();
 });

--- a/frontend/settings/settings.js
+++ b/frontend/settings/settings.js
@@ -511,32 +511,61 @@ style.textContent = `
         from { transform: translateX(0); opacity: 1; }
         to { transform: translateX(100%); opacity: 0; }
     }
-    
+
     /* Theme support */
     .theme-dark {
-        background: #1a1a1a !important;
+        background: #121212 !important;
         color: #e0e0e0 !important;
     }
-    
+
+    .theme-dark .main-content {
+        background: #121212 !important;
+    }
+
     .theme-dark .settings-nav,
     .theme-dark .settings-card,
     .theme-dark .profile-card {
         background: rgba(42, 42, 42, 0.9) !important;
         border-color: rgba(255, 255, 255, 0.1) !important;
     }
-    
+
     .theme-dark .page-header {
         background: rgba(42, 42, 42, 0.9) !important;
         border-color: rgba(255, 255, 255, 0.1) !important;
     }
-    
+
     .theme-dark .page-title,
     .theme-dark .section-title,
     .theme-dark .card-title,
     .theme-dark .setting-name {
         color: #e0e0e0 !important;
     }
-    
+
+    .theme-dark .settings-nav-item {
+        color: #ccc !important;
+    }
+
+    .theme-dark .settings-nav-item:hover {
+        background: rgba(255, 255, 255, 0.05) !important;
+        color: #fff !important;
+    }
+
+    .theme-dark .settings-nav-item.active {
+        background: rgba(255, 255, 255, 0.1) !important;
+        color: #fff !important;
+    }
+
+    .theme-dark .page-subtitle,
+    .theme-dark .section-description,
+    .theme-dark .card-description,
+    .theme-dark .setting-desc,
+    .theme-dark .nav-text,
+    .theme-dark .storage-label,
+    .theme-dark .storage-value,
+    .theme-dark .form-hint {
+        color: #aaa !important;
+    }
+
     .theme-dark input,
     .theme-dark select,
     .theme-dark textarea {
@@ -544,17 +573,31 @@ style.textContent = `
         border-color: rgba(255, 255, 255, 0.2) !important;
         color: #e0e0e0 !important;
     }
-    
+
+    .theme-dark ::-webkit-scrollbar {
+        width: 8px;
+        background: #1a1a1a;
+    }
+
+    .theme-dark ::-webkit-scrollbar-thumb {
+        background: #333;
+        border-radius: 4px;
+    }
+
+    .theme-dark ::-webkit-scrollbar-thumb:hover {
+        background: #444;
+    }
+
     /* Compact mode */
     .compact-mode .settings-card,
     .compact-mode .profile-card {
         padding: 20px !important;
     }
-    
+
     .compact-mode .setting-item {
         padding: 10px 0 !important;
     }
-    
+
     /* No animations */
     .no-animations * {
         animation: none !important;


### PR DESCRIPTION
## Summary
- unify dark theme application by reading user theme on all pages
- style sidebar and layout components for dark mode, including scrollbars
- expand settings page dark theme to cover navigation, text, and backgrounds

## Testing
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d724de354832182f8954743aa05f9