### PR TITLE
Apply global dark theme across app

### DIFF
--- a/frontend/ai/ai.css
+++ b/frontend/ai/ai.css
@@ -6,15 +6,15 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #F7FFF7;
-    color: #090C02;
+    background: var(--page-bg);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
 .page-header {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
     padding: 30px 40px;
     margin-bottom: 30px;
 }
@@ -28,13 +28,13 @@ body {
 .page-title {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 8px;
 }
 
 .page-subtitle {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-muted);
     font-weight: 400;
 }
 
@@ -51,7 +51,7 @@ body {
 }
 
 .upload-section {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 40px;
@@ -71,12 +71,12 @@ body {
 
 .upload-area:hover {
     border-color: rgba(9, 12, 2, 0.4);
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
 }
 
 .upload-area.dragover {
-    border-color: #090C02;
-    background: rgba(9, 12, 2, 0.05);
+    border-color: var(--text-color);
+    background: var(--surface-bg-alt);
     transform: scale(1.02);
 }
 
@@ -95,17 +95,17 @@ body {
 .upload-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .upload-subtitle {
     font-size: 1rem;
-    color: #666;
+    color: var(--text-muted);
     margin-bottom: 10px;
 }
 
 .upload-btn {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border: none;
     padding: 12px 32px;
@@ -132,7 +132,7 @@ body {
     align-items: center;
     gap: 15px;
     padding: 15px;
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
     border-radius: 12px;
 }
 
@@ -143,17 +143,17 @@ body {
 
 .info-text {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .info-text strong {
-    color: #090C02;
+    color: var(--text-color);
     display: block;
     margin-bottom: 2px;
 }
 
 .processing-section {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 60px 40px;
@@ -180,8 +180,8 @@ body {
 .processing-spinner {
     width: 60px;
     height: 60px;
-    border: 4px solid rgba(9, 12, 2, 0.1);
-    border-top: 4px solid #090C02;
+    border: 4px solid var(--border-color);
+    border-top: 4px solid var(--text-color);
     border-radius: 50%;
     animation: spin 1s linear infinite;
 }
@@ -199,7 +199,7 @@ body {
 .processing-dots span {
     width: 8px;
     height: 8px;
-    background: #090C02;
+    background: var(--text-color);
     border-radius: 50%;
     animation: bounce 1.4s ease-in-out infinite both;
 }
@@ -215,12 +215,12 @@ body {
 .processing-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .processing-subtitle {
     font-size: 1rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .processing-steps {
@@ -244,28 +244,28 @@ body {
 .step-number {
     width: 30px;
     height: 30px;
-    background: rgba(9, 12, 2, 0.1);
+    background: var(--border-color);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     font-weight: 600;
     font-size: 0.9rem;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .step.active .step-number {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
 }
 
 .step-text {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .results-section {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 30px;
@@ -279,13 +279,13 @@ body {
     align-items: center;
     margin-bottom: 30px;
     padding-bottom: 20px;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .results-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .results-actions {
@@ -301,7 +301,7 @@ body {
     border: 1px solid rgba(9, 12, 2, 0.2);
     border-radius: 8px;
     background: white;
-    color: #090C02;
+    color: var(--text-color);
     font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
@@ -309,13 +309,13 @@ body {
 }
 
 .action-btn:hover {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     transform: translateY(-2px);
 }
 
 .action-btn.secondary {
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
 }
 
 .btn-icon {
@@ -323,7 +323,7 @@ body {
 }
 
 .document-info {
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
     border-radius: 12px;
     padding: 20px;
     margin-bottom: 25px;
@@ -334,7 +334,7 @@ body {
 
 .doc-icon {
     font-size: 2rem;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .doc-details {
@@ -344,20 +344,20 @@ body {
 .doc-name {
     font-size: 1.1rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 5px;
 }
 
 .doc-meta {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-muted);
     display: flex;
     gap: 20px;
 }
 
 .summary-tabs {
     display: flex;
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     border-radius: 12px;
     padding: 4px;
     margin-bottom: 25px;
@@ -372,18 +372,18 @@ body {
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 500;
-    color: #666;
+    color: var(--text-muted);
     transition: all 0.3s ease;
 }
 
 .summary-tab.active {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
 }
 
 .summary-tab:hover:not(.active) {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 .summary-content {
@@ -403,11 +403,11 @@ body {
 .summary-text {
     font-size: 1rem;
     line-height: 1.8;
-    color: #090C02;
-    background: rgba(9, 12, 2, 0.02);
+    color: var(--text-color);
+    background: var(--surface-bg-alt);
     padding: 25px;
     border-radius: 12px;
-    border-left: 4px solid #090C02;
+    border-left: 4px solid var(--text-color);
 }
 
 .key-points-list {
@@ -421,20 +421,20 @@ body {
     align-items: flex-start;
     gap: 12px;
     padding: 15px;
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
     border-radius: 12px;
 }
 
 .key-point-icon {
     font-size: 1.2rem;
-    color: #090C02;
+    color: var(--text-color);
     flex-shrink: 0;
     margin-top: 2px;
 }
 
 .key-point-text {
     font-size: 0.95rem;
-    color: #090C02;
+    color: var(--text-color);
     line-height: 1.6;
 }
 
@@ -453,13 +453,13 @@ body {
 
 .highlight-text {
     font-size: 0.95rem;
-    color: #090C02;
+    color: var(--text-color);
     line-height: 1.6;
     font-style: italic;
 }
 
 .history-section {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 30px;
@@ -469,7 +469,7 @@ body {
 .history-title {
     font-size: 1.3rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 20px;
 }
 
@@ -484,20 +484,20 @@ body {
     align-items: center;
     gap: 15px;
     padding: 15px;
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
     border-radius: 12px;
     cursor: pointer;
     transition: all 0.3s ease;
 }
 
 .history-item:hover {
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     transform: translateY(-2px);
 }
 
 .history-icon {
     font-size: 1.5rem;
-    color: #090C02;
+    color: var(--text-color);
     flex-shrink: 0;
 }
 
@@ -508,13 +508,13 @@ body {
 .history-name {
     font-size: 1rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 3px;
 }
 
 .history-date {
     font-size: 0.85rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .history-actions {
@@ -529,19 +529,19 @@ body {
     border-radius: 6px;
     cursor: pointer;
     font-size: 1rem;
-    color: #666;
+    color: var(--text-muted);
     transition: all 0.3s ease;
 }
 
 .history-action:hover {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 .empty-history {
     text-align: center;
     padding: 40px;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .empty-icon {
@@ -557,7 +557,7 @@ body {
 
 .empty-subtext {
     font-size: 0.9rem;
-    color: #999;
+    color: var(--text-muted);
 }
 
 @keyframes fadeInUp {

--- a/frontend/ai/ai.html
+++ b/frontend/ai/ai.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperly - AI PDF Summarizer</title>
+    <link rel="stylesheet" href="../common/theme.css">
     <link rel="stylesheet" href="../common/sidebar.css">
     <link rel="stylesheet" href="ai.css">
 </head>

--- a/frontend/auth/auth.css
+++ b/frontend/auth/auth.css
@@ -6,7 +6,7 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #F7FFF7;
+    background: var(--page-bg);
     min-height: 100vh;
     display: flex;
     align-items: center;
@@ -21,7 +21,7 @@ body {
 }
 
 .auth-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     border-radius: 20px;
     padding: 40px;
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
@@ -43,20 +43,20 @@ body {
 .brand-title {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 5px;
     letter-spacing: -0.5px;
 }
 
 .brand-subtitle {
-    color: #666;
+    color: var(--text-muted);
     font-size: 0.9rem;
     font-weight: 400;
 }
 
 .auth-tabs {
     display: flex;
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     border-radius: 12px;
     padding: 4px;
     margin-bottom: 30px;
@@ -71,19 +71,19 @@ body {
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 500;
-    color: #666;
+    color: var(--text-muted);
     transition: all 0.3s ease;
 }
 
 .tab-btn.active {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     transform: translateY(-1px);
 }
 
 .tab-btn:hover:not(.active) {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 .auth-form {
@@ -108,7 +108,7 @@ body {
 .form-group input {
     width: 100%;
     padding: 16px 12px 8px;
-    border: 2px solid rgba(9, 12, 2, 0.1);
+    border: 2px solid var(--border-color);
     border-radius: 12px;
     font-size: 1rem;
     background: rgba(255, 255, 255, 0.8);
@@ -117,10 +117,10 @@ body {
 }
 
 .form-group input:focus {
-    border-color: #090C02;
+    border-color: var(--text-color);
     background: white;
     transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(9, 12, 2, 0.1);
+    box-shadow: 0 4px 12px var(--border-color);
 }
 
 .form-group label {
@@ -128,7 +128,7 @@ body {
     top: 16px;
     left: 12px;
     font-size: 1rem;
-    color: #666;
+    color: var(--text-muted);
     transition: all 0.3s ease;
     pointer-events: none;
 }
@@ -137,7 +137,7 @@ body {
 .form-group input:valid + label {
     top: 8px;
     font-size: 0.8rem;
-    color: #090C02;
+    color: var(--text-color);
     font-weight: 500;
 }
 
@@ -145,7 +145,7 @@ body {
 .auth-btn {
     width: 100%;
     padding: 16px;
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border: none;
     border-radius: 12px;

--- a/frontend/auth/auth.html
+++ b/frontend/auth/auth.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperly - Authentication</title>
+    <link rel="stylesheet" href="../common/theme.css">
     <link rel="stylesheet" href="auth.css">
 </head>
 <body>

--- a/frontend/chatbox/chatbox.css
+++ b/frontend/chatbox/chatbox.css
@@ -6,22 +6,22 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #F7FFF7;
-    color: #090C02;
+    background: var(--page-bg);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
 .chat-container {
     height: 100vh;
     display: flex;
-    background: #F7FFF7;
+    background: var(--page-bg);
 }
 
 .chat-sidebar {
     width: 320px;
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-right: 1px solid rgba(9, 12, 2, 0.1);
+    border-right: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;
     height: 100vh;
@@ -29,7 +29,7 @@ body {
 
 .chat-header {
     padding: 25px 20px;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -38,11 +38,11 @@ body {
 .chat-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .new-chat-btn {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border: none;
     border-radius: 50%;
@@ -66,13 +66,13 @@ body {
 
 .chat-search {
     padding: 20px;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .chat-search input {
     width: 100%;
     padding: 12px 16px;
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    border: 1px solid var(--border-color);
     border-radius: 20px;
     background: rgba(255, 255, 255, 0.8);
     font-size: 0.9rem;
@@ -81,14 +81,14 @@ body {
 }
 
 .chat-search input:focus {
-    border-color: #090C02;
-    box-shadow: 0 0 0 2px rgba(9, 12, 2, 0.1);
+    border-color: var(--text-color);
+    box-shadow: 0 0 0 2px var(--border-color);
 }
 
 .chat-tabs {
     display: flex;
     padding: 15px 20px;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .chat-tab {
@@ -100,18 +100,18 @@ body {
     cursor: pointer;
     font-size: 0.9rem;
     font-weight: 500;
-    color: #666;
+    color: var(--text-muted);
     transition: all 0.3s ease;
 }
 
 .chat-tab.active {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
 }
 
 .chat-tab:hover:not(.active) {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 .chat-list {
@@ -131,19 +131,19 @@ body {
 }
 
 .chat-item:hover {
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
 }
 
 .chat-item.active {
-    background: rgba(9, 12, 2, 0.1);
-    border-left-color: #090C02;
+    background: var(--border-color);
+    border-left-color: var(--text-color);
 }
 
 .chat-avatar {
     width: 45px;
     height: 45px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #090C02, rgba(9, 12, 2, 0.7));
+    background: linear-gradient(135deg, var(--text-color), rgba(9, 12, 2, 0.7));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -161,7 +161,7 @@ body {
 .chat-name {
     font-size: 0.95rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 3px;
     white-space: nowrap;
     overflow: hidden;
@@ -170,7 +170,7 @@ body {
 
 .chat-last-message {
     font-size: 0.85rem;
-    color: #666;
+    color: var(--text-muted);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -186,11 +186,11 @@ body {
 
 .chat-time {
     font-size: 0.8rem;
-    color: #999;
+    color: var(--text-muted);
 }
 
 .chat-unread {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border-radius: 10px;
     padding: 2px 6px;
@@ -217,7 +217,7 @@ body {
 
 .message-input {
     padding: 10px;
-    border-top: 1px solid #ddd;
+    border-top: 1px solid var(--border-color);
     display: flex;
     align-items: center;
     gap: 10px;
@@ -226,13 +226,13 @@ body {
 .message-field {
     flex: 1;
     padding: 10px;
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    border: 1px solid var(--border-color);
     border-radius: 20px;
     outline: none;
 }
 
 .send-btn {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border: none;
     border-radius: 20px;
@@ -264,19 +264,19 @@ body {
 .welcome-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 8px;
 }
 
 .welcome-subtitle {
-    color: #666;
+    color: var(--text-muted);
     font-size: 1rem;
 }
 
 .chat-header-active {
     padding: 20px;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
-    background: rgba(255, 255, 255, 0.9);
+    border-bottom: 1px solid var(--border-color);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     display: flex;
     align-items: center;
@@ -287,7 +287,7 @@ body {
     width: 45px;
     height: 45px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #090C02, rgba(9, 12, 2, 0.7));
+    background: linear-gradient(135deg, var(--text-color), rgba(9, 12, 2, 0.7));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -303,13 +303,13 @@ body {
 .chat-header-name {
     font-size: 1.2rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 2px;
 }
 
 .chat-header-status {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .chat-messages {
@@ -338,7 +338,7 @@ body {
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #090C02, rgba(9, 12, 2, 0.7));
+    background: linear-gradient(135deg, var(--text-color), rgba(9, 12, 2, 0.7));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -349,7 +349,7 @@ body {
 }
 
 .message-content {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     padding: 12px 16px;
     border-radius: 18px;
     border-bottom-left-radius: 4px;
@@ -359,7 +359,7 @@ body {
 }
 
 .message.own .message-content {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 18px;
@@ -382,8 +382,8 @@ body {
 
 .chat-input-area {
     padding: 20px;
-    border-top: 1px solid rgba(9, 12, 2, 0.1);
-    background: rgba(255, 255, 255, 0.9);
+    border-top: 1px solid var(--border-color);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
 }
 
@@ -392,15 +392,15 @@ body {
     align-items: center;
     gap: 10px;
     background: rgba(255, 255, 255, 0.8);
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    border: 1px solid var(--border-color);
     border-radius: 24px;
     padding: 8px 16px;
     transition: all 0.3s ease;
 }
 
 .chat-input-container:focus-within {
-    border-color: #090C02;
-    box-shadow: 0 0 0 2px rgba(9, 12, 2, 0.1);
+    border-color: var(--text-color);
+    box-shadow: 0 0 0 2px var(--border-color);
 }
 
 .attachment-btn {
@@ -411,12 +411,12 @@ body {
     padding: 4px;
     border-radius: 50%;
     transition: all 0.3s ease;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .attachment-btn:hover {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 #messageInput {
@@ -426,15 +426,15 @@ body {
     background: transparent;
     font-size: 1rem;
     padding: 8px 12px;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 #messageInput::placeholder {
-    color: #999;
+    color: var(--text-muted);
 }
 
 .send-btn {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border: none;
     border-radius: 50%;
@@ -505,7 +505,7 @@ body {
 .modal-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .modal-close {
@@ -513,13 +513,13 @@ body {
     border: none;
     font-size: 2rem;
     cursor: pointer;
-    color: #666;
+    color: var(--text-muted);
     padding: 0;
     line-height: 1;
 }
 
 .modal-close:hover {
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .search-users {
@@ -538,8 +538,8 @@ body {
 }
 
 .search-users input:focus {
-    border-color: #090C02;
-    box-shadow: 0 0 0 2px rgba(9, 12, 2, 0.1);
+    border-color: var(--text-color);
+    box-shadow: 0 0 0 2px var(--border-color);
 }
 
 .users-list {
@@ -561,14 +561,14 @@ body {
 }
 
 .user-item:hover {
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
 }
 
 .user-avatar {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #090C02, rgba(9, 12, 2, 0.7));
+    background: linear-gradient(135deg, var(--text-color), rgba(9, 12, 2, 0.7));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -584,13 +584,13 @@ body {
 .user-name {
     font-size: 1rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 2px;
 }
 
 .user-status {
     font-size: 0.85rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 @keyframes fadeInUp {

--- a/frontend/chatbox/chatbox.html
+++ b/frontend/chatbox/chatbox.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Paperly - Chatbox</title>
+    <link rel="stylesheet" href="../common/theme.css">
   <link rel="stylesheet" href="../common/sidebar.css">
   <link rel="stylesheet" href="chatbox.css">
 </head>

--- a/frontend/classroom/classroom-view.css
+++ b/frontend/classroom/classroom-view.css
@@ -7,16 +7,16 @@
 
 body {
     font-family: 'Poppins', sans-serif;
-    background-color: #dee2e6;
-    color: #1c1c1c;
+    background-color: var(--page-bg);
+    color: var(--text-color);
     overflow-x: hidden;
 }
 
 /* Header Styles */
 .classroom-header {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--border-color);
     padding: 1rem 1.5rem;
     position: fixed;
     top: 0;
@@ -41,7 +41,7 @@ body {
 .class-title {
     font-size: 1.5rem;
     font-weight: 700;
-    color: #1c1c1c;
+    color: var(--text-color);
     margin: 0;
 }
 
@@ -49,7 +49,7 @@ body {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    color: #6c757d;
+    color: var(--text-muted);
     font-size: 0.875rem;
 }
 
@@ -76,23 +76,23 @@ body {
 
 .btn-outline {
     background: transparent;
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    color: #6c757d;
+    border: 1px solid var(--border-color);
+    color: var(--text-muted);
 }
 
 .btn-outline:hover {
-    background: rgba(0, 0, 0, 0.05);
-    border-color: rgba(0, 0, 0, 0.3);
+    background: var(--surface-bg-alt);
+    border-color: var(--border-color);
 }
 
 .btn-primary {
-    background: #1c1c1c;
+    background: var(--text-color);
     color: white;
-    border: 1px solid #1c1c1c;
+    border: 1px solid var(--text-color);
 }
 
 .btn-primary:hover {
-    background: #333;
+    background: var(--surface-bg-alt);
     transform: translateY(-1px);
 }
 
@@ -121,9 +121,9 @@ body {
 
 /* Documents Section */
 .documents-section {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--border-color);
     border-radius: 1rem;
     padding: 1.5rem;
     height: 100%;
@@ -137,13 +137,13 @@ body {
     align-items: center;
     margin-bottom: 1.5rem;
     padding-bottom: 1rem;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .section-header h2 {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #1c1c1c;
+    color: var(--text-color);
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -151,11 +151,11 @@ body {
 
 /* Upload Area */
 .upload-area {
-    border: 2px dashed rgba(0, 0, 0, 0.2);
+    border: 2px dashed var(--border-color);
     border-radius: 0.75rem;
     padding: 2rem;
     text-align: center;
-    color: #6c757d;
+    color: var(--text-muted);
     transition: all 0.2s ease;
     cursor: pointer;
     margin-bottom: 1.5rem;
@@ -163,8 +163,8 @@ body {
 }
 
 .upload-area:hover {
-    border-color: #1c1c1c;
-    color: #1c1c1c;
+    border-color: var(--text-color);
+    color: var(--text-color);
     background: rgba(255, 255, 255, 0.8);
 }
 
@@ -172,14 +172,14 @@ body {
     font-size: 2.5rem;
     margin-bottom: 1rem;
     display: block;
-    color: #1c1c1c;
+    color: var(--text-color);
 }
 
 .upload-area h3 {
     font-size: 1.125rem;
     font-weight: 600;
     margin-bottom: 0.5rem;
-    color: #1c1c1c;
+    color: var(--text-color);
 }
 
 .upload-area p {
@@ -189,7 +189,7 @@ body {
 
 .supported-formats {
     font-size: 0.75rem;
-    color: #6c757d;
+    color: var(--text-muted);
     font-style: italic;
 }
 
@@ -208,7 +208,7 @@ body {
     gap: 1rem;
     padding: 1rem;
     background: rgba(255, 255, 255, 0.8);
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--border-color);
     border-radius: 0.75rem;
     transition: all 0.2s ease;
 }
@@ -216,7 +216,7 @@ body {
 .document-item:hover {
     background: rgba(255, 255, 255, 0.95);
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 12px var(--border-color);
 }
 
 .document-icon {
@@ -253,7 +253,7 @@ body {
 .document-details h4 {
     font-size: 1rem;
     font-weight: 600;
-    color: #1c1c1c;
+    color: var(--text-color);
     margin-bottom: 0.25rem;
 }
 
@@ -262,7 +262,7 @@ body {
     align-items: center;
     gap: 1rem;
     font-size: 0.75rem;
-    color: #6c757d;
+    color: var(--text-muted);
 }
 
 .file-size {
@@ -293,11 +293,11 @@ body {
 
 .action-btn.download {
     background: rgba(28, 28, 28, 0.1);
-    color: #1c1c1c;
+    color: var(--text-color);
 }
 
 .action-btn.download:hover {
-    background: #1c1c1c;
+    background: var(--text-color);
     color: white;
 }
 
@@ -314,9 +314,9 @@ body {
 /* Sidebar */
 .sidebar {
     width: 20rem;
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-left: 1px solid rgba(0, 0, 0, 0.1);
+    border-left: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;
     padding: 1.5rem;
@@ -328,13 +328,13 @@ body {
     align-items: center;
     margin-bottom: 1.5rem;
     padding-bottom: 1rem;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .sidebar-header h3 {
     font-size: 1.125rem;
     font-weight: 600;
-    color: #1c1c1c;
+    color: var(--text-color);
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -342,8 +342,8 @@ body {
 
 .participant-count {
     font-size: 0.875rem;
-    color: #6c757d;
-    background: rgba(0, 0, 0, 0.05);
+    color: var(--text-muted);
+    background: var(--surface-bg-alt);
     padding: 0.25rem 0.75rem;
     border-radius: 1rem;
 }
@@ -364,7 +364,7 @@ body {
     gap: 0.75rem;
     padding: 0.75rem;
     background: rgba(255, 255, 255, 0.8);
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--border-color);
     border-radius: 0.5rem;
     transition: all 0.2s ease;
 }
@@ -386,7 +386,7 @@ body {
 .avatar-circle {
     width: 2.5rem;
     height: 2.5rem;
-    background: #1c1c1c;
+    background: var(--text-color);
     color: white;
     border-radius: 50%;
     display: flex;
@@ -428,15 +428,15 @@ body {
 .participant-details h4 {
     font-size: 0.875rem;
     font-weight: 500;
-    color: #1c1c1c;
+    color: var(--text-color);
 }
 
 .role-badge {
     font-size: 0.75rem;
     padding: 0.125rem 0.5rem;
     border-radius: 1rem;
-    background: rgba(0, 0, 0, 0.1);
-    color: #6c757d;
+    background: var(--border-color);
+    color: var(--text-muted);
     width: fit-content;
 }
 
@@ -447,14 +447,14 @@ body {
 
 .join-time {
     font-size: 0.75rem;
-    color: #6c757d;
+    color: var(--text-muted);
     font-style: italic;
 }
 
 /* Classroom Stats */
 .classroom-stats {
     padding-top: 1rem;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    border-top: 1px solid var(--border-color);
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
@@ -468,11 +468,11 @@ body {
     background: rgba(255, 255, 255, 0.8);
     border-radius: 0.375rem;
     font-size: 0.875rem;
-    color: #1c1c1c;
+    color: var(--text-color);
 }
 
 .stat-item i {
-    color: #6c757d;
+    color: var(--text-muted);
     width: 1rem;
 }
 
@@ -502,7 +502,7 @@ body {
         width: 100%;
         height: 40vh;
         border-left: none;
-        border-top: 1px solid rgba(0, 0, 0, 0.1);
+        border-top: 1px solid var(--border-color);
     }
     
     .main-content {
@@ -531,12 +531,12 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-    background: rgba(0, 0, 0, 0.1);
+    background: var(--border-color);
     border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--border-color);
     border-radius: 3px;
 }
 
@@ -574,7 +574,7 @@ body {
     width: 20px;
     height: 20px;
     margin: -10px 0 0 -10px;
-    border: 2px solid #1c1c1c;
+    border: 2px solid var(--text-color);
     border-radius: 50%;
     border-top-color: transparent;
     animation: spin 1s linear infinite;

--- a/frontend/classroom/classroom-view.html
+++ b/frontend/classroom/classroom-view.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Classroom - Advanced Mathematics</title>
+    <link rel="stylesheet" href="../common/theme.css">
     <link rel="stylesheet" href="classroom-view.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">

--- a/frontend/classroom/classroom.css
+++ b/frontend/classroom/classroom.css
@@ -7,15 +7,15 @@
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: #F7FFF7;
-  color: #090C02;
+  background: var(--page-bg);
+  color: var(--text-color);
   line-height: 1.6;
 }
 
 .page-header {
-  background: rgba(248, 248, 246, 0.9);
+  background: var(--surface-bg);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(9, 12, 2, 0.2);
+  border-bottom: 1px solid var(--border-color);
   padding: 30px 40px;
   margin-bottom: 30px;
 }
@@ -28,13 +28,13 @@ body {
 .page-title {
   font-size: 2.5rem;
   font-weight: 700;
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 8px;
 }
 
 .page-subtitle {
   font-size: 1.1rem;
-  color: #090C02;
+  color: var(--text-color);
   font-weight: 400;
   opacity: 0.8;
 }
@@ -53,11 +53,11 @@ body {
 }
 
 .classroom-card {
-  background: rgba(248, 248, 246, 0.9);
+  background: var(--surface-bg);
   backdrop-filter: blur(10px);
   border-radius: 20px;
   padding: 30px;
-  border: 1px solid rgba(248, 248, 246, 0.3);
+  border: 1px solid var(--border-color);
   transition: all 0.3s ease;
   animation: fadeInUp 0.6s ease-out;
 }
@@ -83,15 +83,15 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(9, 12, 2, 0.1);
+  background: var(--border-color);
   border-radius: 12px;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .card-title {
   font-size: 1.4rem;
   font-weight: 600;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .classroom-form {
@@ -108,7 +108,7 @@ body {
 
 .form-group label {
   font-weight: 500;
-  color: #090C02;
+  color: var(--text-color);
   font-size: 0.9rem;
 }
 
@@ -121,11 +121,11 @@ body {
   background: rgba(255, 255, 255, 0.8);
   transition: all 0.3s ease;
   outline: none;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .form-group input:focus {
-  border-color: #090C02;
+  border-color: var(--text-color);
   box-shadow: 0 0 0 2px rgba(9, 12, 2, 0.2);
   background: white;
 }
@@ -153,7 +153,7 @@ body {
 }
 
 .btn-primary {
-  background: #090C02;
+  background: var(--text-color);
   color: white;
 }
 
@@ -175,12 +175,12 @@ body {
 .btn-primary:hover {
   transform: translateY(-2px);
   box-shadow: 0 8px 20px rgba(9, 12, 2, 0.4);
-  background: #1a1f0a;
+  background: var(--text-color);
 }
 
 .btn-secondary {
   background: rgba(9, 12, 2, 0.15);
-  color: #090C02;
+  color: var(--text-color);
   border: 1px solid rgba(9, 12, 2, 0.3);
 }
 
@@ -201,7 +201,7 @@ body {
 .section-title {
   font-size: 1.5rem;
   font-weight: 600;
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 20px;
 }
 
@@ -212,11 +212,11 @@ body {
 }
 
 .recent-classroom-item {
-  background: rgba(248, 248, 246, 0.9);
+  background: var(--surface-bg);
   backdrop-filter: blur(10px);
   border-radius: 16px;
   padding: 20px;
-  border: 1px solid rgba(248, 248, 246, 0.3);
+  border: 1px solid var(--border-color);
   transition: all 0.3s ease;
   cursor: pointer;
 }
@@ -240,20 +240,20 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(9, 12, 2, 0.1);
+  background: var(--border-color);
   border-radius: 10px;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .recent-classroom-name {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .recent-classroom-subject {
   font-size: 0.9rem;
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 8px;
   opacity: 0.8;
 }
@@ -263,7 +263,7 @@ body {
   justify-content: space-between;
   align-items: center;
   font-size: 0.85rem;
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.7;
 }
 
@@ -272,7 +272,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: 40px;
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.7;
 }
 
@@ -280,7 +280,7 @@ body {
   width: 20px;
   height: 20px;
   border: 2px solid rgba(9, 12, 2, 0.2);
-  border-top: 2px solid #090C02;
+  border-top: 2px solid var(--text-color);
   border-radius: 50%;
   animation: spin 1s linear infinite;
   margin-right: 10px;
@@ -371,7 +371,7 @@ body {
 }
 
 .modal-content {
-  background: rgba(248, 248, 246, 0.95);
+  background: var(--surface-bg);
   backdrop-filter: blur(10px);
   border-radius: 20px;
   padding: 30px;
@@ -403,7 +403,7 @@ body {
 .modal-title {
   font-size: 1.5rem;
   font-weight: 600;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .modal-close {
@@ -411,7 +411,7 @@ body {
   border: none;
   font-size: 2rem;
   cursor: pointer;
-  color: #090C02;
+  color: var(--text-color);
   padding: 0;
   line-height: 1;
   opacity: 0.7;
@@ -424,7 +424,7 @@ body {
 /* Classroom View Styles */
 .classroom-tabs {
   display: flex;
-  background: rgba(9, 12, 2, 0.1);
+  background: var(--border-color);
   border-radius: 12px;
   padding: 4px;
   margin-bottom: 25px;
@@ -439,13 +439,13 @@ body {
   cursor: pointer;
   font-size: 0.9rem;
   font-weight: 500;
-  color: #090C02;
+  color: var(--text-color);
   transition: all 0.3s ease;
   opacity: 0.7;
 }
 
 .classroom-tab.active {
-  background: #090C02;
+  background: var(--text-color);
   color: white;
   opacity: 1;
 }
@@ -471,13 +471,13 @@ body {
 
 /* Overview Tab */
 .classroom-info {
-  background: rgba(9, 12, 2, 0.05);
+  background: var(--surface-bg-alt);
   border-radius: 12px;
   padding: 20px;
 }
 
 .classroom-info h3 {
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 15px;
   font-size: 1.2rem;
 }
@@ -494,7 +494,7 @@ body {
   justify-content: space-between;
   align-items: center;
   padding: 10px 0;
-  border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .info-item:last-child {
@@ -503,11 +503,11 @@ body {
 
 .info-label {
   font-weight: 500;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .info-value {
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.8;
 }
 
@@ -519,13 +519,13 @@ body {
 }
 
 .upload-section {
-  background: rgba(9, 12, 2, 0.05);
+  background: var(--surface-bg-alt);
   border-radius: 12px;
   padding: 25px;
 }
 
 .upload-section h3 {
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 20px;
   font-size: 1.2rem;
 }
@@ -546,13 +546,13 @@ body {
 }
 
 .upload-area:hover {
-  border-color: #090C02;
-  background: rgba(9, 12, 2, 0.05);
+  border-color: var(--text-color);
+  background: var(--surface-bg-alt);
 }
 
 .upload-area.dragover {
-  border-color: #090C02;
-  background: rgba(9, 12, 2, 0.1);
+  border-color: var(--text-color);
+  background: var(--border-color);
   transform: scale(1.02);
 }
 
@@ -565,24 +565,24 @@ body {
 
 .upload-icon {
   font-size: 3rem;
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.6;
 }
 
 .upload-content h4 {
-  color: #090C02;
+  color: var(--text-color);
   font-size: 1.1rem;
   margin-bottom: 5px;
 }
 
 .upload-content p {
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.7;
   font-size: 0.9rem;
 }
 
 .resources-list h3 {
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 20px;
   font-size: 1.2rem;
 }
@@ -594,7 +594,7 @@ body {
 }
 
 .resource-item {
-  background: rgba(248, 248, 246, 0.9);
+  background: var(--surface-bg);
   border: 1px solid rgba(9, 12, 2, 0.2);
   border-radius: 12px;
   padding: 20px;
@@ -620,9 +620,9 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(9, 12, 2, 0.1);
+  background: var(--border-color);
   border-radius: 8px;
-  color: #090C02;
+  color: var(--text-color);
 }
 
 .resource-info {
@@ -632,18 +632,18 @@ body {
 .resource-title {
   font-size: 1rem;
   font-weight: 600;
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 3px;
 }
 
 .resource-meta {
   font-size: 0.85rem;
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.7;
 }
 
 .resource-description {
-  color: #090C02;
+  color: var(--text-color);
   font-size: 0.9rem;
   margin-bottom: 15px;
   opacity: 0.8;
@@ -660,7 +660,7 @@ body {
   border: 1px solid rgba(9, 12, 2, 0.3);
   border-radius: 6px;
   background: white;
-  color: #090C02;
+  color: var(--text-color);
   font-size: 0.85rem;
   font-weight: 500;
   cursor: pointer;
@@ -672,23 +672,23 @@ body {
 }
 
 .resource-btn:hover {
-  background: #090C02;
+  background: var(--text-color);
   color: white;
 }
 
 .resource-btn.primary {
-  background: #090C02;
+  background: var(--text-color);
   color: white;
-  border-color: #090C02;
+  border-color: var(--text-color);
 }
 
 .resource-btn.primary:hover {
-  background: #1a1f0a;
+  background: var(--text-color);
 }
 
 /* Members Tab */
 .members-section h3 {
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 20px;
   font-size: 1.2rem;
 }
@@ -704,7 +704,7 @@ body {
   align-items: center;
   gap: 12px;
   padding: 15px;
-  background: rgba(9, 12, 2, 0.05);
+  background: var(--surface-bg-alt);
   border-radius: 10px;
 }
 
@@ -712,7 +712,7 @@ body {
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #090C02, rgba(9, 12, 2, 0.7));
+  background: linear-gradient(135deg, var(--text-color), rgba(9, 12, 2, 0.7));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -727,20 +727,20 @@ body {
 
 .member-name {
   font-weight: 500;
-  color: #090C02;
+  color: var(--text-color);
   margin-bottom: 2px;
 }
 
 .member-role {
   font-size: 0.85rem;
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.7;
 }
 
 .empty-resources {
   text-align: center;
   padding: 40px;
-  color: #090C02;
+  color: var(--text-color);
   opacity: 0.7;
 }
 

--- a/frontend/classroom/classroom.html
+++ b/frontend/classroom/classroom.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Paperly - Manage Your Classrooms</title>
+    <link rel="stylesheet" href="../common/theme.css">
   <link rel="stylesheet" href="../common/sidebar.css" />
   <link rel="stylesheet" href="classroom.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/frontend/common/sidebar.css
+++ b/frontend/common/sidebar.css
@@ -5,9 +5,9 @@
     left: 0;
     width: 260px;
     height: 100vh;
-    background: rgba(255, 255, 255, 0.95);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-right: 1px solid rgba(9, 12, 2, 0.1);
+    border-right: 1px solid var(--border-color);
     z-index: 1000;
     transition: all 0.3s ease;
     display: flex;
@@ -21,7 +21,7 @@
 
 .sidebar-header {
     padding: 20px;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -38,7 +38,7 @@
 .brand-title {
     font-size: 1.5rem;
     font-weight: 700;
-    color: #090C02;
+    color: var(--text-color);
     white-space: nowrap;
     transition: opacity 0.3s ease;
 }
@@ -66,13 +66,13 @@
 }
 
 .sidebar-toggle:hover {
-    background: rgba(9, 12, 2, 0.1);
+    background: var(--border-color);
 }
 
 .hamburger {
     width: 20px;
     height: 2px;
-    background: #090C02;
+    background: var(--text-color);
     position: relative;
     transition: all 0.3s ease;
 }
@@ -83,7 +83,7 @@
     position: absolute;
     width: 20px;
     height: 2px;
-    background: #090C02;
+    background: var(--text-color);
     transition: all 0.3s ease;
 }
 
@@ -120,7 +120,7 @@
     align-items: center;
     gap: 12px;
     padding: 12px 20px;
-    color: #666;
+    color: var(--text-muted);
     text-decoration: none;
     transition: all 0.3s ease;
     position: relative;
@@ -129,13 +129,13 @@
 }
 
 .nav-item:hover {
-    background: rgba(9, 12, 2, 0.05);
-    color: #090C02;
+    background: var(--surface-bg-alt);
+    color: var(--text-color);
 }
 
 .nav-item.active {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
     font-weight: 500;
 }
 
@@ -146,7 +146,7 @@
     top: 0;
     bottom: 0;
     width: 3px;
-    background: #090C02;
+    background: var(--text-color);
     border-radius: 0 2px 2px 0;
 }
 
@@ -177,7 +177,7 @@
 
 .sidebar-footer {
     padding: 20px;
-    border-top: 1px solid rgba(9, 12, 2, 0.1);
+    border-top: 1px solid var(--border-color);
 }
 
 .logout-btn {
@@ -198,7 +198,7 @@
     margin-left: 260px;
     transition: margin-left 0.3s ease;
     min-height: 100vh;
-    background: #F7FFF7;
+    background: var(--page-bg);
 }
 
 /* Mobile Responsive */
@@ -257,54 +257,3 @@
     background: rgba(9, 12, 2, 0.3);
 }
 
-/* Dark theme */
-.theme-dark .sidebar {
-    background: rgba(33, 33, 33, 0.95);
-    border-color: rgba(255, 255, 255, 0.1);
-}
-
-.theme-dark .sidebar-header,
-.theme-dark .sidebar-footer {
-    border-color: rgba(255, 255, 255, 0.1);
-}
-
-.theme-dark .brand-title,
-.theme-dark .nav-item,
-.theme-dark .nav-icon,
-.theme-dark .nav-text,
-.theme-dark .logout-btn {
-    color: #e0e0e0;
-}
-
-.theme-dark .sidebar-toggle:hover,
-.theme-dark .nav-item:hover {
-    background: rgba(255, 255, 255, 0.05);
-    color: #fff;
-}
-
-.theme-dark .nav-item.active {
-    background: rgba(255, 255, 255, 0.1);
-    color: #fff;
-}
-
-.theme-dark .nav-item.active::before {
-    background: #fff;
-}
-
-.theme-dark .hamburger,
-.theme-dark .hamburger::before,
-.theme-dark .hamburger::after {
-    background: #e0e0e0;
-}
-
-.theme-dark .main-content {
-    background: #121212;
-}
-
-.theme-dark .sidebar-nav::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.2);
-}
-
-.theme-dark .sidebar-nav::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.3);
-}

--- a/frontend/common/theme.css
+++ b/frontend/common/theme.css
@@ -1,0 +1,24 @@
+:root {
+  --page-bg: #F7FFF7;
+  --text-color: #090C02;
+  --text-muted: #666;
+  --surface-bg: rgba(255, 255, 255, 0.9);
+  --surface-bg-alt: rgba(9, 12, 2, 0.03);
+  --border-color: rgba(9, 12, 2, 0.1);
+}
+
+body {
+  background: var(--page-bg);
+  color: var(--text-color);
+}
+
+body.theme-dark {
+  --page-bg: #121212;
+  --text-color: #e0e0e0;
+  --text-muted: #bbbbbb;
+  --surface-bg: rgba(42, 42, 42, 0.9);
+  --surface-bg-alt: rgba(255, 255, 255, 0.05);
+  --border-color: rgba(255, 255, 255, 0.1);
+  color: var(--text-color);
+  background: var(--page-bg);
+}

--- a/frontend/dashboard/dashboard.css
+++ b/frontend/dashboard/dashboard.css
@@ -6,15 +6,15 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #F7FFF7;
-    color: #090C02;
+    background: var(--page-bg);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
 .page-header {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
     padding: 30px 40px;
     margin-bottom: 30px;
 }
@@ -28,12 +28,12 @@ body {
     font-size: 2.5rem;
     font-weight: 700;
     margin-bottom: 8px;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .page-subtitle {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-muted);
     font-weight: 400;
 }
 
@@ -58,7 +58,7 @@ body {
 }
 
 .stat-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 16px;
     padding: 25px;
@@ -82,7 +82,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     border-radius: 12px;
 }
 
@@ -93,13 +93,13 @@ body {
 .stat-number {
     font-size: 2rem;
     font-weight: 700;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 4px;
 }
 
 .stat-label {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-muted);
     font-weight: 500;
 }
 
@@ -107,7 +107,7 @@ body {
 .quick-actions,
 .recent-notes,
 .group-updates {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 30px;
@@ -125,13 +125,13 @@ body {
 .section-title {
     font-size: 1.4rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .view-all-btn {
     background: none;
     border: none;
-    color: #090C02;
+    color: var(--text-color);
     font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
@@ -141,7 +141,7 @@ body {
 }
 
 .view-all-btn:hover {
-    background: rgba(9, 12, 2, 0.1);
+    background: var(--border-color);
 }
 
 .activity-list {
@@ -155,7 +155,7 @@ body {
     align-items: center;
     gap: 15px;
     padding: 15px 0;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.05);
+    border-bottom: 1px solid var(--surface-bg-alt);
 }
 
 .activity-item:last-child {
@@ -169,7 +169,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     border-radius: 10px;
     flex-shrink: 0;
 }
@@ -181,13 +181,13 @@ body {
 .activity-title {
     font-size: 1rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 4px;
 }
 
 .activity-time {
     font-size: 0.85rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .actions-grid {
@@ -197,8 +197,8 @@ body {
 }
 
 .action-card {
-    background: rgba(9, 12, 2, 0.03);
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    background: var(--surface-bg-alt);
+    border: 1px solid var(--border-color);
     border-radius: 12px;
     padding: 20px;
     cursor: pointer;
@@ -211,7 +211,7 @@ body {
 }
 
 .action-card:hover {
-    background: rgba(9, 12, 2, 0.08);
+    background: var(--surface-bg-alt);
     transform: translateY(-3px);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
 }
@@ -224,7 +224,7 @@ body {
 .action-title {
     font-size: 0.9rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .notes-list,
@@ -240,14 +240,14 @@ body {
     align-items: center;
     gap: 15px;
     padding: 15px 0;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.05);
+    border-bottom: 1px solid var(--surface-bg-alt);
     cursor: pointer;
     transition: all 0.3s ease;
 }
 
 .note-item:hover,
 .update-item:hover {
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
     border-radius: 8px;
     padding: 15px;
     margin: 0 -15px;
@@ -266,7 +266,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     border-radius: 10px;
     flex-shrink: 0;
 }
@@ -280,7 +280,7 @@ body {
 .update-title {
     font-size: 1rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 4px;
 }
 
@@ -293,12 +293,12 @@ body {
 .note-date,
 .update-time {
     font-size: 0.85rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .note-tag {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
     padding: 2px 8px;
     border-radius: 4px;
     font-size: 0.8rem;
@@ -396,15 +396,15 @@ body {
 .joined-classrooms-container {
   margin-top: 30px;
   padding: 15px;
-  background: #f9f9f9;
+  background: var(--surface-bg);
   border-radius: 10px;
 }
 
 .joined-classroom-card {
   padding: 10px;
   margin-bottom: 8px;
-  background-color: #fff;
-  border: 1px solid #ddd;
+  background-color: var(--surface-bg);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   font-weight: 500;
 }

--- a/frontend/dashboard/dashboard.html
+++ b/frontend/dashboard/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperly - Dashboard</title>
+    <link rel="stylesheet" href="../common/theme.css">
     <link rel="stylesheet" href="../common/sidebar.css">
     <link rel="stylesheet" href="dashboard.css">
 </head>

--- a/frontend/home/home.css
+++ b/frontend/home/home.css
@@ -6,15 +6,15 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #F7FFF7;
-    color: #090C02;
+    background: var(--page-bg);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
 .page-header {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
     padding: 30px 40px;
     margin-bottom: 40px;
 }
@@ -28,12 +28,12 @@ body {
     font-size: 2.5rem;
     font-weight: 700;
     margin-bottom: 8px;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .page-subtitle {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-muted);
     font-weight: 400;
 }
 
@@ -60,19 +60,19 @@ body {
     font-size: 3rem;
     font-weight: 700;
     margin-bottom: 20px;
-    color: #090C02;
+    color: var(--text-color);
     line-height: 1.2;
 }
 
 .hero-description {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-muted);
     margin-bottom: 30px;
     line-height: 1.8;
 }
 
 .cta-button {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     padding: 16px 32px;
     border: none;
@@ -114,7 +114,7 @@ body {
 }
 
 .floating-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 30px;
@@ -127,7 +127,7 @@ body {
 .card-header {
     font-size: 1.2rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 20px;
     text-align: center;
 }
@@ -140,7 +140,7 @@ body {
 
 .card-line {
     height: 8px;
-    background: linear-gradient(90deg, #090C02, rgba(9, 12, 2, 0.3));
+    background: linear-gradient(90deg, var(--text-color), rgba(9, 12, 2, 0.3));
     border-radius: 4px;
     animation: shimmer 2s ease-in-out infinite;
 }
@@ -179,7 +179,7 @@ body {
     font-weight: 700;
     text-align: center;
     margin-bottom: 50px;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .features-grid {
@@ -189,7 +189,7 @@ body {
 }
 
 .feature-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 30px;
@@ -207,7 +207,7 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(135deg, rgba(9, 12, 2, 0.02), transparent);
+    background: linear-gradient(135deg, var(--surface-bg-alt), transparent);
     opacity: 0;
     transition: opacity 0.3s ease;
 }
@@ -231,11 +231,11 @@ body {
     font-size: 1.4rem;
     font-weight: 600;
     margin-bottom: 12px;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .feature-description {
-    color: #666;
+    color: var(--text-muted);
     margin-bottom: 20px;
     line-height: 1.6;
 }
@@ -243,7 +243,7 @@ body {
 .feature-arrow {
     font-size: 1.2rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     opacity: 0;
     transform: translateX(-10px);
     transition: all 0.3s ease;
@@ -255,7 +255,7 @@ body {
 }
 
 .stats-section {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 20px;
     padding: 50px;
@@ -279,14 +279,14 @@ body {
 .stat-number {
     font-size: 3rem;
     font-weight: 700;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 8px;
     animation: countUp 2s ease-out;
 }
 
 .stat-label {
     font-size: 1rem;
-    color: #666;
+    color: var(--text-muted);
     font-weight: 500;
 }
 

--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperly - Home</title>
+    <link rel="stylesheet" href="../common/theme.css">
     <link rel="stylesheet" href="../common/sidebar.css">
     <link rel="stylesheet" href="home.css">
 </head>

--- a/frontend/notes/notes.css
+++ b/frontend/notes/notes.css
@@ -6,15 +6,15 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #F7FFF7;
-    color: #090C02;
+    background: var(--page-bg);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
 .page-header {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
     padding: 30px 40px;
     margin-bottom: 30px;
 }
@@ -30,11 +30,11 @@ body {
 .page-title {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .create-note-btn {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
     border: none;
     padding: 12px 24px;
@@ -75,10 +75,10 @@ body {
 .search-bar {
     display: flex;
     align-items: center;
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     border-radius: 12px;
     padding: 4px;
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    border: 1px solid var(--border-color);
     flex: 1;
     max-width: 400px;
 }
@@ -103,7 +103,7 @@ body {
 }
 
 .search-btn:hover {
-    background: rgba(9, 12, 2, 0.1);
+    background: var(--border-color);
 }
 
 .filter-controls {
@@ -114,17 +114,17 @@ body {
 
 .filter-select {
     padding: 8px 12px;
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    border: 1px solid var(--border-color);
     border-radius: 8px;
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     font-size: 0.9rem;
     cursor: pointer;
     outline: none;
 }
 
 .view-toggle {
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    background: var(--surface-bg);
+    border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 8px 12px;
     cursor: pointer;
@@ -133,7 +133,7 @@ body {
 }
 
 .view-toggle:hover {
-    background: rgba(9, 12, 2, 0.1);
+    background: var(--border-color);
 }
 
 .notes-grid {
@@ -148,7 +148,7 @@ body {
 }
 
 .note-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 16px;
     padding: 25px;
@@ -171,7 +171,7 @@ body {
     left: 0;
     right: 0;
     height: 4px;
-    background: linear-gradient(90deg, #090C02, rgba(9, 12, 2, 0.3));
+    background: linear-gradient(90deg, var(--text-color), rgba(9, 12, 2, 0.3));
 }
 
 .note-header {
@@ -184,14 +184,14 @@ body {
 .note-title {
     font-size: 1.3rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 8px;
     line-height: 1.3;
 }
 
 .note-type {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
     padding: 4px 8px;
     border-radius: 6px;
     font-size: 0.8rem;
@@ -200,7 +200,7 @@ body {
 }
 
 .note-content {
-    color: #666;
+    color: var(--text-muted);
     font-size: 0.95rem;
     line-height: 1.6;
     margin-bottom: 15px;
@@ -219,8 +219,8 @@ body {
 }
 
 .note-pdf {
-    background: rgba(9, 12, 2, 0.05);
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    background: var(--surface-bg-alt);
+    border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 20px;
     text-align: center;
@@ -247,8 +247,8 @@ body {
 }
 
 .note-tag {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
     padding: 2px 6px;
     border-radius: 4px;
     font-size: 0.8rem;
@@ -271,7 +271,7 @@ body {
 }
 
 .action-btn:hover {
-    background: rgba(9, 12, 2, 0.1);
+    background: var(--border-color);
 }
 
 .action-btn.delete:hover {
@@ -281,7 +281,7 @@ body {
 
 .note-date {
     font-size: 0.85rem;
-    color: #999;
+    color: var(--text-muted);
     margin-top: 8px;
 }
 
@@ -334,7 +334,7 @@ body {
 .modal-title {
     font-size: 1.5rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .modal-close {
@@ -342,13 +342,13 @@ body {
     border: none;
     font-size: 2rem;
     cursor: pointer;
-    color: #666;
+    color: var(--text-muted);
     padding: 0;
     line-height: 1;
 }
 
 .modal-close:hover {
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .note-form {
@@ -365,7 +365,7 @@ body {
 
 .form-group label {
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     font-size: 0.9rem;
 }
 
@@ -384,8 +384,8 @@ body {
 .form-group input:focus,
 .form-group select:focus,
 .form-group textarea:focus {
-    border-color: #090C02;
-    box-shadow: 0 0 0 2px rgba(9, 12, 2, 0.1);
+    border-color: var(--text-color);
+    box-shadow: 0 0 0 2px var(--border-color);
 }
 
 .form-group textarea {
@@ -396,7 +396,7 @@ body {
 .file-preview {
     margin-top: 10px;
     padding: 10px;
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     border-radius: 8px;
     display: none;
 }
@@ -431,8 +431,8 @@ body {
 }
 
 .cancel-btn {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 .cancel-btn:hover {
@@ -440,7 +440,7 @@ body {
 }
 
 .save-btn {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
 }
 

--- a/frontend/notes/notes.html
+++ b/frontend/notes/notes.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperly - Notes</title>
+    <link rel="stylesheet" href="../common/theme.css">
     <link rel="stylesheet" href="../common/sidebar.css">
     <link rel="stylesheet" href="notes.css">
 </head>

--- a/frontend/settings/settings.css
+++ b/frontend/settings/settings.css
@@ -6,15 +6,15 @@
 
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #F7FFF7;
-    color: #090C02;
+    background: var(--page-bg);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
 .page-header {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
     padding: 30px 40px;
     margin-bottom: 30px;
 }
@@ -27,13 +27,13 @@ body {
 .page-title {
     font-size: 2.5rem;
     font-weight: 700;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 8px;
 }
 
 .page-subtitle {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-muted);
     font-weight: 400;
 }
 
@@ -56,7 +56,7 @@ body {
 }
 
 .settings-nav {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 16px;
     padding: 20px;
@@ -75,19 +75,19 @@ body {
     cursor: pointer;
     font-size: 0.95rem;
     font-weight: 500;
-    color: #666;
+    color: var(--text-muted);
     transition: all 0.3s ease;
     margin-bottom: 4px;
 }
 
 .settings-nav-item:hover {
-    background: rgba(9, 12, 2, 0.05);
-    color: #090C02;
+    background: var(--surface-bg-alt);
+    color: var(--text-color);
 }
 
 .settings-nav-item.active {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 .nav-icon {
@@ -126,18 +126,18 @@ body {
 .section-title {
     font-size: 2rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 8px;
 }
 
 .section-description {
     font-size: 1rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .settings-card,
 .profile-card {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-bg);
     backdrop-filter: blur(10px);
     border-radius: 16px;
     padding: 30px;
@@ -153,13 +153,13 @@ body {
 .card-title {
     font-size: 1.3rem;
     font-weight: 600;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 8px;
 }
 
 .card-description {
     font-size: 0.95rem;
-    color: #666;
+    color: var(--text-muted);
     margin-bottom: 20px;
 }
 
@@ -169,14 +169,14 @@ body {
     gap: 20px;
     margin-bottom: 30px;
     padding-bottom: 20px;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .profile-avatar {
     width: 80px;
     height: 80px;
     border-radius: 50%;
-    background: linear-gradient(135deg, #090C02, rgba(9, 12, 2, 0.7));
+    background: linear-gradient(135deg, var(--text-color), rgba(9, 12, 2, 0.7));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -196,7 +196,7 @@ body {
     border: 1px solid rgba(9, 12, 2, 0.2);
     border-radius: 6px;
     background: white;
-    color: #090C02;
+    color: var(--text-color);
     font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
@@ -204,12 +204,12 @@ body {
 }
 
 .avatar-btn:hover {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
 }
 
 .avatar-btn.secondary {
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
 }
 
 .profile-form,
@@ -233,7 +233,7 @@ body {
 
 .form-group label {
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     font-size: 0.9rem;
 }
 
@@ -252,19 +252,19 @@ body {
 .form-group input:focus,
 .form-group select:focus,
 .form-group textarea:focus {
-    border-color: #090C02;
-    box-shadow: 0 0 0 2px rgba(9, 12, 2, 0.1);
+    border-color: var(--text-color);
+    box-shadow: 0 0 0 2px var(--border-color);
 }
 
 .form-group input:disabled,
 .form-group select:disabled {
-    background: rgba(9, 12, 2, 0.05);
-    color: #666;
+    background: var(--surface-bg-alt);
+    color: var(--text-muted);
     cursor: not-allowed;
 }
 
 .form-group input[readonly] {
-    background: rgba(9, 12, 2, 0.05);
+    background: var(--surface-bg-alt);
     cursor: default;
 }
 
@@ -275,7 +275,7 @@ body {
 
 .form-hint {
     font-size: 0.85rem;
-    color: #999;
+    color: var(--text-muted);
     margin-top: 4px;
 }
 
@@ -298,7 +298,7 @@ body {
 }
 
 .btn-primary {
-    background: #090C02;
+    background: var(--text-color);
     color: white;
 }
 
@@ -308,8 +308,8 @@ body {
 }
 
 .btn-secondary {
-    background: rgba(9, 12, 2, 0.1);
-    color: #090C02;
+    background: var(--border-color);
+    color: var(--text-color);
 }
 
 .btn-secondary:hover {
@@ -343,7 +343,7 @@ body {
     justify-content: space-between;
     align-items: center;
     padding: 15px 0;
-    border-bottom: 1px solid rgba(9, 12, 2, 0.05);
+    border-bottom: 1px solid var(--surface-bg-alt);
 }
 
 .setting-item:last-child {
@@ -357,13 +357,13 @@ body {
 .setting-name {
     font-size: 1rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
     margin-bottom: 3px;
 }
 
 .setting-desc {
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .setting-control {
@@ -409,7 +409,7 @@ body {
 }
 
 .toggle-switch input:checked + .toggle-slider {
-    background: #090C02;
+    background: var(--text-color);
 }
 
 .toggle-switch input:checked + .toggle-slider:before {
@@ -433,12 +433,12 @@ body {
 }
 
 .theme-option:hover {
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
 }
 
 .theme-option.active {
-    border-color: #090C02;
-    background: rgba(9, 12, 2, 0.05);
+    border-color: var(--text-color);
+    background: var(--surface-bg-alt);
 }
 
 .theme-preview {
@@ -447,11 +447,11 @@ body {
     border-radius: 8px;
     margin: 0 auto 10px;
     overflow: hidden;
-    border: 1px solid rgba(9, 12, 2, 0.1);
+    border: 1px solid var(--border-color);
 }
 
 .theme-preview.light {
-    background: #F7FFF7;
+    background: var(--page-bg);
 }
 
 .theme-preview.dark {
@@ -459,13 +459,13 @@ body {
 }
 
 .theme-preview.auto {
-    background: linear-gradient(45deg, #F7FFF7 50%, #1a1a1a 50%);
+    background: linear-gradient(45deg, var(--page-bg) 50%, #1a1a1a 50%);
 }
 
 .theme-header {
     height: 15px;
-    background: rgba(255, 255, 255, 0.9);
-    border-bottom: 1px solid rgba(9, 12, 2, 0.1);
+    background: var(--surface-bg);
+    border-bottom: 1px solid var(--border-color);
 }
 
 .theme-preview.dark .theme-header {
@@ -480,7 +480,7 @@ body {
 .theme-sidebar {
     width: 20px;
     background: rgba(255, 255, 255, 0.7);
-    border-right: 1px solid rgba(9, 12, 2, 0.1);
+    border-right: 1px solid var(--border-color);
 }
 
 .theme-preview.dark .theme-sidebar {
@@ -489,7 +489,7 @@ body {
 
 .theme-main {
     flex: 1;
-    background: rgba(9, 12, 2, 0.02);
+    background: var(--surface-bg-alt);
 }
 
 .theme-preview.dark .theme-main {
@@ -499,7 +499,7 @@ body {
 .theme-name {
     font-size: 0.9rem;
     font-weight: 500;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 .data-actions,
@@ -524,21 +524,21 @@ body {
 .storage-label {
     width: 100px;
     font-size: 0.9rem;
-    color: #090C02;
+    color: var(--text-color);
     font-weight: 500;
 }
 
 .storage-bar {
     flex: 1;
     height: 8px;
-    background: rgba(9, 12, 2, 0.1);
+    background: var(--border-color);
     border-radius: 4px;
     overflow: hidden;
 }
 
 .storage-fill {
     height: 100%;
-    background: #090C02;
+    background: var(--text-color);
     border-radius: 4px;
     transition: width 0.3s ease;
 }
@@ -547,15 +547,15 @@ body {
     width: 60px;
     text-align: right;
     font-size: 0.9rem;
-    color: #666;
+    color: var(--text-muted);
 }
 
 .storage-total {
     margin-top: 15px;
     padding-top: 15px;
-    border-top: 1px solid rgba(9, 12, 2, 0.1);
+    border-top: 1px solid var(--border-color);
     font-size: 0.95rem;
-    color: #090C02;
+    color: var(--text-color);
 }
 
 /* Mobile Responsive */

--- a/frontend/settings/settings.html
+++ b/frontend/settings/settings.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paperly - Settings</title>
+    <link rel="stylesheet" href="../common/theme.css">
     <link rel="stylesheet" href="../common/sidebar.css">
     <link rel="stylesheet" href="settings.css">
 </head>

--- a/frontend/settings/settings.js
+++ b/frontend/settings/settings.js
@@ -500,7 +500,7 @@ document.addEventListener('DOMContentLoaded', () => {
     settingsManager = new SettingsManager();
 });
 
-// Add CSS for animations and theme support
+// Add CSS for animations
 const style = document.createElement('style');
 style.textContent = `
     @keyframes slideIn {
@@ -512,83 +512,6 @@ style.textContent = `
         to { transform: translateX(100%); opacity: 0; }
     }
 
-    /* Theme support */
-    .theme-dark {
-        background: #121212 !important;
-        color: #e0e0e0 !important;
-    }
-
-    .theme-dark .main-content {
-        background: #121212 !important;
-    }
-
-    .theme-dark .settings-nav,
-    .theme-dark .settings-card,
-    .theme-dark .profile-card {
-        background: rgba(42, 42, 42, 0.9) !important;
-        border-color: rgba(255, 255, 255, 0.1) !important;
-    }
-
-    .theme-dark .page-header {
-        background: rgba(42, 42, 42, 0.9) !important;
-        border-color: rgba(255, 255, 255, 0.1) !important;
-    }
-
-    .theme-dark .page-title,
-    .theme-dark .section-title,
-    .theme-dark .card-title,
-    .theme-dark .setting-name {
-        color: #e0e0e0 !important;
-    }
-
-    .theme-dark .settings-nav-item {
-        color: #ccc !important;
-    }
-
-    .theme-dark .settings-nav-item:hover {
-        background: rgba(255, 255, 255, 0.05) !important;
-        color: #fff !important;
-    }
-
-    .theme-dark .settings-nav-item.active {
-        background: rgba(255, 255, 255, 0.1) !important;
-        color: #fff !important;
-    }
-
-    .theme-dark .page-subtitle,
-    .theme-dark .section-description,
-    .theme-dark .card-description,
-    .theme-dark .setting-desc,
-    .theme-dark .nav-text,
-    .theme-dark .storage-label,
-    .theme-dark .storage-value,
-    .theme-dark .form-hint {
-        color: #aaa !important;
-    }
-
-    .theme-dark input,
-    .theme-dark select,
-    .theme-dark textarea {
-        background: rgba(255, 255, 255, 0.1) !important;
-        border-color: rgba(255, 255, 255, 0.2) !important;
-        color: #e0e0e0 !important;
-    }
-
-    .theme-dark ::-webkit-scrollbar {
-        width: 8px;
-        background: #1a1a1a;
-    }
-
-    .theme-dark ::-webkit-scrollbar-thumb {
-        background: #333;
-        border-radius: 4px;
-    }
-
-    .theme-dark ::-webkit-scrollbar-thumb:hover {
-        background: #444;
-    }
-
-    /* Compact mode */
     .compact-mode .settings-card,
     .compact-mode .profile-card {
         padding: 20px !important;


### PR DESCRIPTION
## Summary
- add global theme stylesheet with light/dark CSS variables
- refactor feature styles to use theme variables
- load shared theme on every page and remove redundant dark-mode overrides

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 403 Forbidden - GET https://registry.npmjs.org/concurrently)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da1d7f9a48321b6a95ab5b2de1021