### PR TITLE
Implement password change and account deletion

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -52,4 +52,44 @@ const login = async (req, res) => {
   }
 };
 
-module.exports = { register, login };
+// Change Password Controller
+const changePassword = async (req, res) => {
+  const userId = req.user.id || req.user._id;
+  const { currentPassword, newPassword } = req.body;
+
+  try {
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    const isMatch = await bcrypt.compare(currentPassword, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ message: 'Current password is incorrect' });
+    }
+
+    const salt = await bcrypt.genSalt(10);
+    user.password = await bcrypt.hash(newPassword, salt);
+    await user.save();
+
+    res.status(200).json({ message: 'Password updated successfully' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error during password change' });
+  }
+};
+
+// Delete Account Controller
+const deleteAccount = async (req, res) => {
+  const userId = req.user.id || req.user._id;
+
+  try {
+    await User.findByIdAndDelete(userId);
+    res.status(200).json({ message: 'Account deleted successfully' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error during account deletion' });
+  }
+};
+
+module.exports = { register, login, changePassword, deleteAccount };

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,11 +1,18 @@
 const express = require('express');
 const router = express.Router();
-const { register, login } = require('../controllers/authController');
+const { register, login, changePassword, deleteAccount } = require('../controllers/authController');
+const auth = require('../middleware/auth');
 
 // Route for signup
 router.post('/register', register);
 
 // Route for login
 router.post('/login', login);
+
+// Route for changing password
+router.put('/change-password', auth, changePassword);
+
+// Route for deleting account
+router.delete('/delete-account', auth, deleteAccount);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- support password updates and account deletion on backend
- wire settings page to use new API endpoints

## Testing
- `node --check backend/controllers/authController.js && echo 'syntax ok'`
- `node --check backend/routes/authRoutes.js && echo 'syntax ok'`
- `node --check frontend/settings/settings.js && echo 'syntax ok'`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6f6bee6e8832182e0f4e7a9757436